### PR TITLE
Add snake_case validation for Role fields in protobuf definitions

### DIFF
--- a/internal/descriptor/services.go
+++ b/internal/descriptor/services.go
@@ -3,6 +3,7 @@ package descriptor
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	options "google.golang.org/genproto/googleapis/api/annotations"
@@ -13,6 +14,20 @@ import (
 	myoptions "github.com/go-core-stack/grpc-core/coreapis/api"
 	"github.com/go-core-stack/grpc-core/internal/httprule"
 )
+
+// Regular expression to validate snake_case format
+var snakeCaseRegex = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+// validateSnakeCase checks if a string is in valid snake_case format
+func validateSnakeCase(field, value string) error {
+	if value == "" {
+		return nil // Empty values are allowed
+	}
+	if !snakeCaseRegex.MatchString(value) {
+		return fmt.Errorf("field '%s' with value '%s' is not in snake_case format", field, value)
+	}
+	return nil
+}
 
 // loadServices registers services and their methods from "targetFile" to "r".
 // It must be called after loadFile is called for all files so that loadServices
@@ -238,6 +253,20 @@ func extractRoleOptions(meth *descriptorpb.MethodDescriptorProto) (*myoptions.Ro
 	if !ok {
 		return nil, fmt.Errorf("extension is %T; want a Role", ext)
 	}
+
+	// Validate Role fields for snake_case format
+	if err := validateSnakeCase("resource", role.Resource); err != nil {
+		return nil, fmt.Errorf("invalid role in method %s: %w", meth.GetName(), err)
+	}
+	if err := validateSnakeCase("verb", role.Verb); err != nil {
+		return nil, fmt.Errorf("invalid role in method %s: %w", meth.GetName(), err)
+	}
+	for i, scope := range role.Scope {
+		if err := validateSnakeCase(fmt.Sprintf("scope[%d]", i), scope); err != nil {
+			return nil, fmt.Errorf("invalid role in method %s: %w", meth.GetName(), err)
+		}
+	}
+
 	return role, nil
 }
 


### PR DESCRIPTION
Implement regex-based validation to enforce snake_case naming convention for Role fields (resource, verb, scope) in protobuf method options. This ensures consistent naming across all services using the gRPC core library.

Invalid formats like camelCase or PascalCase will
cause build failures with descriptive error messages indicating the specific field and invalid value.

Changes:
- Add snakeCaseRegex pattern: ^[a-z][a-z0-9]*(_[a-z0-9]+)*$